### PR TITLE
7614 alterar core test

### DIFF
--- a/test/auaupi/core_test.clj
+++ b/test/auaupi/core_test.clj
@@ -1,11 +1,11 @@
 (ns auaupi.core-test
-  (:require
-   [clojure.test :refer [testing deftest is]]
-   [matcher-combinators.test :refer [match?]]
-   [user]
-   [auaupi.datomic :as datomic]
-   [auaupi.core :as core]
-   [helpers]))
+  (:require [auaupi.core :as core]
+            [clojure.test :refer [testing deftest is]]
+            [matcher-combinators.test :refer [match?]]
+            [io.pedestal.http :as http]
+            [io.pedestal.test :as http-test]
+            [clojure.data.json :as json]
+            [auaupi.db :as db]))
 
 (defn make-request! [verb path & args]
   (let [service-fn (::http/service-fn (core/create-server))
@@ -13,70 +13,82 @@
     (update response :body json/read-str
             :key-fn keyword)))
 
-(deftest dogs-listing-not-adopteds
-  (user/delete-db)
-  (datomic/prepare-datomic! core/config-map)
-  (helpers/initial-dogs!)
-  (testing "Query consult"
-    (is (match?  [[3 "Xenon" "Weimaraner" "https://images.dog.ceo/breeds/weimaraner/n02092339_747.jpg"]
-                  [1 "Bardock" "Mix" "https://images.dog.ceo/breeds/mix/piper.jpg"]
-                  [5 "Melinda" "Pitbull" "https://images.dog.ceo/breeds/pitbull/IMG_20190826_121528_876.jpg"]
-                  [4 "Thor" "Pitbull" "https://images.dog.ceo/breeds/pitbull/IMG_20190826_121528_876.jpg"]]
-                 (datomic/find-dogs  (datomic/open-connection core/config-map)))))
-
-
-  (testing "New dog"
-    (is (match?  [6
-                  "Elo"
-                  "African"
-                  "f"
-                  "p"
-                  "2016-07-21"]
-
-                 (let [coll
-                       (:tx-data
-                        (datomic/transact-dog!
-                         {:dog/id (datomic/inc-last-id (datomic/open-connection core/config-map))
-                          :dog/name "Elo"
-                          :dog/breed "African"
-                          :dog/gender "f"
-                          :dog/port "p"
-                          :dog/birth "2016-07-21"} core/config-map))]
-                   (into [] (rest (map (fn [coll] (nth coll 2 :not-found)) coll)))))))
-  
-  (testing "One dog"
-    (is (match?  [[2
-                   "Leka"
-                   "Maltese"
-                   "https://images.dog.ceo/breeds/maltese/n02085936_4781.jpg"
-                   "p"
-                   "f"
-                   "2019-05-05"
-                   true
-                   true]]
-                 (datomic/find-dog-by-id 2 (datomic/open-connection core/config-map)))))
-  #_(testing "listing dog after post"
+(deftest testing-routes
+  (testing "listing dogs"
+    (is (match? {:body [{:dog/id 3
+                         :dog/name "Xenon"
+                         :dog/breed "Weimaraner"
+                         :dog/img
+                         "https://images.dog.ceo/breeds/weimaraner/n02092339_747.jpg"}
+                        {:dog/id 1
+                         :dog/name "Bardock"
+                         :dog/breed "Mix"
+                         :dog/img
+                         "https://images.dog.ceo/breeds/mix/piper.jpg"}
+                        {:dog/id 5
+                         :dog/name "Melinda"
+                         :dog/breed "Pitbull"
+                         :dog/img
+                         "https://images.dog.ceo/breeds/pitbull/IMG_20190826_121528_876.jpg"}
+                        {:dog/id 4
+                         :dog/name "Thor"
+                         :dog/breed "Pitbull"
+                         :dog/img
+                         "https://images.dog.ceo/breeds/pitbull/IMG_20190826_121528_876.jpg"}] :status 200}
+                (make-request! :get "/dogs"))))
+  (testing "listing dog by id"
+    (is (match? {:body [{:img "https://images.dog.ceo/breeds/weimaraner/n02092339_747.jpg"
+                         :breed "Weimaraner"
+                         :castrated? false
+                         :port "g"
+                         :name "Xenon"
+                         :id 3
+                         :birth "2018-08-14"
+                         :gender "m"
+                         :adopted? false}] :status 200}
+                (make-request! :get "/dogs/3"))))
+  (testing "testing post route"
+    (is (match? {:body {:status 200
+                        :body "Registered Dog"}}
+                (make-request! :post "/dogs"
+                               :headers {"Content-Type" "application/json"}
+                               :body (json/write-str {:name "Caramelo"
+                                                      :breed "stbernard"
+                                                      :age 2
+                                                      :gender "m"
+                                                      :castrated? false
+                                                      :port "p"
+                                                      :adopted? false})))))
+  (testing "listing dog after post"
+    (is (match? {:body [{:breed "stbernard"
+                         :castrated? false
+                         :name "Caramelo"
+                         :port "p"
+                         :id 6
+                         :gender "m"
+                         :adopted? false
+                         :img (fn [dog] (:img dog) (first @db/dogs))
+                         :birth ""}] :status 200}
+                (make-request! :get "/dogs/6"))))
+  (testing "testing adopt a dog"
+    (is (match? {:body "Parabéns, você acabou de dar um novo lar para o Caramelo!"}
+                (make-request! :post "/dogs/6"
+                               :headers {"Content-Type" "application/json"}))))
+  #_(testing "listing a dog by name" ;;CRIAR FIND NO DATOMIC PELO NAME
       (is (match? {:body [{:id "4"
                            :breed "stbernard"
                            :name "caramelo"
                            :img (fn [dog] (:img dog) (first @db/dogs))}] :status 200}
-                  (make-request! :get "/dogs"))))
+                  (make-request! :get "/dogs?name=Caramelo"))))
 
-  #_(testing "listing a dog by name"
-      (is (match? {:body [{:id "4"
-                           :breed "stbernard"
-                           :name "caramelo"
-                           :img (fn [dog] (:img dog) (first @db/dogs))}] :status 200}
-                  (make-request! :get "/dogs?name=caramelo"))))
-
-  #_(testing "listing a dog by breed"
+  #_(testing "listing a dog by breed" ;;CRIAR FIND NO DATOMIC PELA BREED
       (is (match? {:body [{:id "4"
                            :breed "stbernard"
                            :name "caramelo"
                            :img (fn [dog] (:img dog) (first @db/dogs))}] :status 200}
                   (make-request! :get "/dogs?breed=stbernard"))))
 
-  #_(testing "testing castrated filter"
+  #_(testing "testing castrated filter" ;;CRIAR FIND NO DATOMIC PELO CASTRATED
       (is (match? {:body [{:id "4"
                            :breed "stbernard"
                            :name "caramelo"
@@ -103,15 +115,4 @@
                            :name "caramelo"
                            :img (fn [dog] (:img dog) (first @db/dogs))}] :status 200}
                   (make-request! :get "/dogs?gender=m"))))
-
-  #_(testing "listing dog by id"
-      (is (match? {:body [{:id "4"
-                           :breed "stbernard"
-                           :name "caramelo"
-                           :img (fn [dog] (:img dog) (first @db/dogs))}] :status 200}
-                  (make-request! :get "/dogs/4"))))
-
-  #_(testing "testing adopt a dog"
-      (is (match? {:body "Parabéns, você acabou de dar um novo lar para o caramelo!"}
-                  (make-request! :post "/dogs/4"
-                                 :headers {"Content-Type" "application/json"})))))
+)

--- a/test/auaupi/core_test.clj
+++ b/test/auaupi/core_test.clj
@@ -5,7 +5,10 @@
             [io.pedestal.http :as http]
             [io.pedestal.test :as http-test]
             [clojure.data.json :as json]
-            [auaupi.db :as db]))
+            [auaupi.db :as db]
+            [auaupi.datomic :as datomic]
+            [helpers]
+            [user]))
 
 (defn make-request! [verb path & args]
   (let [service-fn (::http/service-fn (core/create-server))
@@ -14,6 +17,9 @@
             :key-fn keyword)))
 
 (deftest testing-routes
+  (user/delete-db)
+  (datomic/prepare-datomic! core/config-map)
+  (helpers/initial-dogs!)
   (testing "listing dogs"
     (is (match? {:body [{:dog/id 3
                          :dog/name "Xenon"
@@ -114,5 +120,4 @@
                            :breed "stbernard"
                            :name "caramelo"
                            :img (fn [dog] (:img dog) (first @db/dogs))}] :status 200}
-                  (make-request! :get "/dogs?gender=m"))))
-)
+                  (make-request! :get "/dogs?gender=m")))))

--- a/test/auaupi/core_test.clj
+++ b/test/auaupi/core_test.clj
@@ -1,11 +1,11 @@
 (ns auaupi.core-test
-  (:require [auaupi.core :as core]
-            [clojure.test :refer [testing deftest is]]
-            [matcher-combinators.test :refer [match?]]
-            [io.pedestal.http :as http]
-            [io.pedestal.test :as http-test]
-            [clojure.data.json :as json]
-            [auaupi.db :as db]))
+  (:require
+   [clojure.test :refer [testing deftest is]]
+   [matcher-combinators.test :refer [match?]]
+   [user]
+   [auaupi.datomic :as datomic]
+   [auaupi.core :as core]
+   [helpers]))
 
 (defn make-request! [verb path & args]
   (let [service-fn (::http/service-fn (core/create-server))
@@ -14,88 +14,104 @@
             :key-fn keyword)))
 
 (deftest dogs-listing-not-adopteds
-  (testing "listing dogs"
-    (reset! db/dogs [])
-    (is (match? {:body [] :status 200}
-                (make-request! :get "/dogs"))))
-    (testing "testing post route"
-      (is (match? {:body {:id "4"
-                          :name "caramelo"
-                          :breed "stbernard"
-                          :age 2
-                          :gender "m"
-                          :castrated? false
-                          :port "p"
-                          :adopted? false
-                          :img (fn [dog] (:img dog) (first @db/dogs))}}
-                  (make-request! :post "/dogs"
-                                 :headers {"Content-Type" "application/json"}
-                                 :body (json/write-str {:id "4"
-                                                        :name "caramelo"
-                                                        :breed "stbernard"
-                                                        :age 2
-                                                        :gender "m"
-                                                        :castrated? false
-                                                        :port "p"
-                                                        :adopted? false})))))
+  (user/delete-db)
+  (datomic/prepare-datomic! core/config-map)
+  (helpers/initial-dogs!)
+  (testing "Query consult"
+    (is (match?  [[3 "Xenon" "Weimaraner" "https://images.dog.ceo/breeds/weimaraner/n02092339_747.jpg"]
+                  [1 "Bardock" "Mix" "https://images.dog.ceo/breeds/mix/piper.jpg"]
+                  [5 "Melinda" "Pitbull" "https://images.dog.ceo/breeds/pitbull/IMG_20190826_121528_876.jpg"]
+                  [4 "Thor" "Pitbull" "https://images.dog.ceo/breeds/pitbull/IMG_20190826_121528_876.jpg"]]
+                 (datomic/find-dogs  (datomic/open-connection core/config-map)))))
 
-  (testing "listing dog after post"
-    (is (match? {:body [{:id "4"
-                         :breed "stbernard"
-                         :name "caramelo"
-                         :img (fn [dog] (:img dog) (first @db/dogs))}] :status 200}
-                (make-request! :get "/dogs"))))
 
-  (testing "listing a dog by name"
-    (is (match? {:body [{:id "4"
-                         :breed "stbernard"
-                         :name "caramelo"
-                         :img (fn [dog] (:img dog) (first @db/dogs))}] :status 200}
-                (make-request! :get "/dogs?name=caramelo"))))
+  (testing "New dog"
+    (is (match?  [6
+                  "Elo"
+                  "African"
+                  "f"
+                  "p"
+                  "2016-07-21"]
 
-  (testing "listing a dog by breed"
-    (is (match? {:body [{:id "4"
-                         :breed "stbernard"
-                         :name "caramelo"
-                         :img (fn [dog] (:img dog) (first @db/dogs))}] :status 200}
-                (make-request! :get "/dogs?breed=stbernard"))))
+                 (let [coll
+                       (:tx-data
+                        (datomic/transact-dog!
+                         {:dog/id (datomic/inc-last-id (datomic/open-connection core/config-map))
+                          :dog/name "Elo"
+                          :dog/breed "African"
+                          :dog/gender "f"
+                          :dog/port "p"
+                          :dog/birth "2016-07-21"} core/config-map))]
+                   (into [] (rest (map (fn [coll] (nth coll 2 :not-found)) coll)))))))
+  
+  (testing "One dog"
+    (is (match?  [[2
+                   "Leka"
+                   "Maltese"
+                   "https://images.dog.ceo/breeds/maltese/n02085936_4781.jpg"
+                   "p"
+                   "f"
+                   "2019-05-05"
+                   true
+                   true]]
+                 (datomic/find-dog-by-id 2 (datomic/open-connection core/config-map)))))
+  #_(testing "listing dog after post"
+      (is (match? {:body [{:id "4"
+                           :breed "stbernard"
+                           :name "caramelo"
+                           :img (fn [dog] (:img dog) (first @db/dogs))}] :status 200}
+                  (make-request! :get "/dogs"))))
 
-  (testing "testing castrated filter"
-    (is (match? {:body [{:id "4"
-                         :breed "stbernard"
-                         :name "caramelo"
-                         :img (fn [dog] (:img dog) (first @db/dogs))}] :status 200}
-                (make-request! :get "/dogs?castrated?=false"))))
+  #_(testing "listing a dog by name"
+      (is (match? {:body [{:id "4"
+                           :breed "stbernard"
+                           :name "caramelo"
+                           :img (fn [dog] (:img dog) (first @db/dogs))}] :status 200}
+                  (make-request! :get "/dogs?name=caramelo"))))
 
-  (testing "testing age filter"
-    (is (match? {:body [{:id "4"
-                         :breed "stbernard"
-                         :name "caramelo"
-                         :img (fn [dog] (:img dog) (first @db/dogs))}] :status 200}
-                (make-request! :get "/dogs?age=2"))))
+  #_(testing "listing a dog by breed"
+      (is (match? {:body [{:id "4"
+                           :breed "stbernard"
+                           :name "caramelo"
+                           :img (fn [dog] (:img dog) (first @db/dogs))}] :status 200}
+                  (make-request! :get "/dogs?breed=stbernard"))))
 
-  (testing "testing port filter"
-    (is (match? {:body [{:id "4"
-                         :breed "stbernard"
-                         :name "caramelo"
-                         :img (fn [dog] (:img dog) (first @db/dogs))}] :status 200}
-                (make-request! :get "/dogs?port=p"))))
+  #_(testing "testing castrated filter"
+      (is (match? {:body [{:id "4"
+                           :breed "stbernard"
+                           :name "caramelo"
+                           :img (fn [dog] (:img dog) (first @db/dogs))}] :status 200}
+                  (make-request! :get "/dogs?castrated?=false"))))
 
-  (testing "testing gender filter"
-    (is (match? {:body [{:id "4"
-                         :breed "stbernard"
-                         :name "caramelo"
-                         :img (fn [dog] (:img dog) (first @db/dogs))}] :status 200}
-                (make-request! :get "/dogs?gender=m"))))
+  #_(testing "testing age filter"
+      (is (match? {:body [{:id "4"
+                           :breed "stbernard"
+                           :name "caramelo"
+                           :img (fn [dog] (:img dog) (first @db/dogs))}] :status 200}
+                  (make-request! :get "/dogs?age=2"))))
 
-  (testing "listing dog by id"
-    (is (match? {:body [{:id "4"
-                         :breed "stbernard"
-                         :name "caramelo"
-                         :img (fn [dog] (:img dog) (first @db/dogs))}] :status 200}
-                (make-request! :get "/dogs/4"))))
+  #_(testing "testing port filter"
+      (is (match? {:body [{:id "4"
+                           :breed "stbernard"
+                           :name "caramelo"
+                           :img (fn [dog] (:img dog) (first @db/dogs))}] :status 200}
+                  (make-request! :get "/dogs?port=p"))))
 
-(testing "testing adopt a dog"
-    (is (match? {:body "Parabéns, você acabou de dar um novo lar para o caramelo!"}
-                (make-request! :post "/dogs/4"
-                               :headers {"Content-Type" "application/json"})))))
+  #_(testing "testing gender filter"
+      (is (match? {:body [{:id "4"
+                           :breed "stbernard"
+                           :name "caramelo"
+                           :img (fn [dog] (:img dog) (first @db/dogs))}] :status 200}
+                  (make-request! :get "/dogs?gender=m"))))
+
+  #_(testing "listing dog by id"
+      (is (match? {:body [{:id "4"
+                           :breed "stbernard"
+                           :name "caramelo"
+                           :img (fn [dog] (:img dog) (first @db/dogs))}] :status 200}
+                  (make-request! :get "/dogs/4"))))
+
+  #_(testing "testing adopt a dog"
+      (is (match? {:body "Parabéns, você acabou de dar um novo lar para o caramelo!"}
+                  (make-request! :post "/dogs/4"
+                                 :headers {"Content-Type" "application/json"})))))

--- a/test/auaupi/logic_test.clj
+++ b/test/auaupi/logic_test.clj
@@ -66,29 +66,4 @@
 
       (testing "format request"
         (is (match? {:castrated? true}
-                    (logic/req->treated {:castrated? "true"}))))
-
-      (testing "response dog male"
-        (is (match? {:body
-                     "Parabéns, você acabou de dar um novo lar para o Xenon!"}
-                    (logic/response-adopted {:id "2"
-                                             :name "Xenon"
-                                             :breed "Weimaraner"
-                                             :img "https://images.dog.ceo/breeds/weimaraner/n02092339_747.jpg"
-                                             :age 2
-                                             :gender "M"
-                                             :castrated? false
-                                             :port "G"
-                                             :adopted? false}))))
-      (testing "response dog female"
-        (is (match? {:body
-                     "Parabéns, você acabou de dar um novo lar para a Leka!"}
-                    (logic/response-adopted {:id "1"
-                                             :name "Leka"
-                                             :breed "Maltese"
-                                             :img "https://images.dog.ceo/breeds/maltese/n02085936_4781.jpg"
-                                             :age 8
-                                             :gender "F"
-                                             :castrated? true
-                                             :port "P"
-                                             :adopted? false}))))))
+                    (logic/req->treated {:castrated? "true"}))))))


### PR DESCRIPTION
Refatorei os testes de rotas do namespace core_test. Pois houve necessidade agora que estamos migrando do atom para o Datomic. 
Deixei alguns testes comentados, pois será necessário criar um novo "find" do Datomic para utilizar os filtros que serão testados depois.