### PR TITLE
Refactoring function names in not_logic (handler) namespace

### DIFF
--- a/src/auaupi/core.clj
+++ b/src/auaupi/core.clj
@@ -4,7 +4,7 @@
    [io.pedestal.http :as http]
    [auaupi.datomic :as datomic]
    [auaupi.config :as config]
-   [auaupi.not-logic :as not-logic]
+   [auaupi.handler :as not-logic]
    [auaupi.service :as service]))
 
 (defn start []

--- a/src/auaupi/logic.clj
+++ b/src/auaupi/logic.clj
@@ -3,7 +3,8 @@
    [clojure.data.json :as json]
    [auaupi.db :as db]
    [clojure.edn :as edn]
-   [auaupi.datomic :as datomic]))
+   [auaupi.datomic :as datomic]
+   [auaupi.schema :as schema]))
 
 (defn transform-keyword [coll]
   (let [k (keys coll)
@@ -89,3 +90,13 @@
                      :dog/birth birth
                      :dog/castrated? castrated?
                      :dog/adopted? adopted?}))))
+
+(defn invalid-breed? [breed breeds]
+  (empty? (filter #(= (clojure.string/lower-case breed) %) breeds)))
+
+(defn invalid-dog? [dog]
+  (not= (schema/validate-schema dog) dog))
+
+(defn invalid-body-response [message]
+  (-> {:status 400}
+      (assoc :body (json/write-str {:message message}))))

--- a/src/auaupi/routes.clj
+++ b/src/auaupi/routes.clj
@@ -6,7 +6,7 @@
     [core :as api]
     [helpers :refer [before defbefore defhandler handler]]]
    [route-swagger.doc :as sw.doc]
-   [auaupi.not-logic :as not-logic]
+   [auaupi.handler :as not-logic]
    [auaupi.datomic :as datomic]
    [auaupi.logic :as logic]
    [auaupi.config :as config]
@@ -37,7 +37,7 @@
 (defn post-dogs [ctx]
   (let [req (get ctx :request)]
     (->> req
-         (not-logic/check-breed! config/config-map)
+         (not-logic/create-dog! config/config-map)
          (assoc ctx :response))))
 
 (defn post-adoption [ctx]


### PR DESCRIPTION
**not_logic -> handler**. A handler is a common name to store impure functions to deal with external world (http requests, db transactions, etc)

**Renaming some function names to properly indicate their actions**. Functions with "check" or "valid" in their names should only make logic or business validations.